### PR TITLE
feat: agrega endpoints product y simples create

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,3 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY ./app ./app
 
 ENV PYTHONUNBUFFERED=1
-
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/cruds/price_crud.py
+++ b/app/cruds/price_crud.py
@@ -1,0 +1,21 @@
+from sqlalchemy.orm import Session
+from app.models.models import Prices, Products
+
+def create_price(db: Session, product_id: int, store_id: int, price: int, url: str) -> Prices:
+    db_price = Prices(
+        product_id=product_id,
+        store_id=store_id,
+        price=price,
+        url=url
+    )
+    db.add(db_price)
+    db.commit()
+    db.refresh(db_price)
+
+    product = db.query(Products).filter(Products.id == product_id).first()
+    if product and (product.min_price is None or price < product.min_price):
+        product.min_price = price
+        db.commit()
+        db.refresh(product)
+
+    return db_price

--- a/app/cruds/product_crud.py
+++ b/app/cruds/product_crud.py
@@ -1,0 +1,69 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+from typing import List, Optional
+from app.models.models import Products
+
+def get_products(
+    db: Session,
+    name: Optional[str] = None,
+    min_price: Optional[int] = None,
+    max_price: Optional[int] = None,
+    game: Optional[str] = None,
+    product_type: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100
+) -> List[Products]:
+    query = db.query(Products)
+
+    filters = []
+
+    if name:
+        filters.append(Products.name.ilike(f"%{name}%"))
+
+    if min_price is not None:
+        filters.append(Products.min_price >= min_price)
+
+    if max_price is not None:
+        filters.append(Products.min_price <= max_price) # ASUMO que filtraremos por min_price del producto
+
+    if game:
+        filters.append(Products.game.ilike(f"%{game}%"))
+
+    if product_type:
+        filters.append(Products.product_type.ilike(f"%{product_type}%"))
+
+    if filters:
+        query = query.filter(and_(*filters))
+
+    return query.offset(skip).limit(limit).all()
+
+def get_product_by_id(db: Session, product_id: int) -> Optional[Products]:
+    return db.query(Products).filter(Products.id == product_id).first()
+
+def create_product(
+    db: Session,
+    name: str,
+    game: str,
+    product_type: str,
+    img_url: Optional[str] = None,
+    min_price: Optional[int] = None,
+    edition: Optional[str] = None,
+    language: Optional[str] = None,
+    description: Optional[str] = None,
+    condition: Optional[str] = None,
+) -> Products:
+    db_product = Products(
+        name=name,
+        img_url=img_url,
+        min_price=min_price,
+        game=game,
+        edition=edition,
+        language=language,
+        description=description,
+        condition=condition,
+        product_type=product_type
+    )
+    db.add(db_product)
+    db.commit()
+    db.refresh(db_product)
+    return db_product

--- a/app/cruds/store_crud.py
+++ b/app/cruds/store_crud.py
@@ -1,0 +1,9 @@
+from sqlalchemy.orm import Session
+from app.models.models import Stores
+
+def create_store(db: Session, name: str, website_url: str) -> Stores:
+    db_store = Stores(name=name, website_url=website_url)
+    db.add(db_store)
+    db.commit()
+    db.refresh(db_store)
+    return db_store

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,20 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+from sqlmodel import SQLModel
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost:5432/mydb")
+
+engine = create_engine(DATABASE_URL)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def create_db_and_tables():
+    SQLModel.metadata.create_all(engine)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from .routers import cards
+from .routers import cards, product_router, price_router, store_router
 from fastapi.middleware.cors import CORSMiddleware
 
 origins = [
@@ -20,7 +20,9 @@ app.add_middleware(
 )
 
 app.include_router(cards.router)
-
+app.include_router(product_router.router)
+app.include_router(price_router.router)
+app.include_router(store_router.router)
 
 @app.get("/")
 def read_root():

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,13 +1,15 @@
-
 from datetime import datetime
 from sqlalchemy import Column, DateTime, func
 from pydantic import EmailStr
 from sqlmodel import Field, Relationship, SQLModel
+from typing import List, Optional
 
 class Stores(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(max_length=255, nullable=False)
-    website_url: str = Field(nullable = False, max_length=255)
+    website_url: str = Field(nullable=False, max_length=255)
+
+    prices: List["Prices"] = Relationship(back_populates="store")
 
 class Products(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
@@ -21,10 +23,15 @@ class Products(SQLModel, table=True):
     condition: str | None = Field(default=None, max_length=20)
     product_type: str = Field(max_length=20, nullable=False)
 
+    prices: List["Prices"] = Relationship(back_populates="product")
+
 class Prices(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     product_id: int = Field(foreign_key="products.id", nullable=False)
     store_id: int = Field(foreign_key="stores.id", nullable=False)
     price: int = Field(nullable=False)
     url: str = Field(max_length=255, nullable=False)
-    scrapped_at: datetime  = Field(sa_column=Column(DateTime(timezone=True), default=func.now(), onupdate=func.now()))
+    scrapped_at: datetime = Field(sa_column=Column(DateTime(timezone=True), default=func.now(), onupdate=func.now()))
+
+    product: Optional[Products] = Relationship(back_populates="prices")
+    store: Optional[Stores] = Relationship(back_populates="prices")

--- a/app/routers/price_router.py
+++ b/app/routers/price_router.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.schema.product_schemas import (
+    PriceResponse,
+    PriceCreate
+)
+from app.cruds.product_crud import get_product_by_id
+from app.cruds.price_crud import create_price
+from app.models.models import Stores
+
+
+from app.database import get_db
+
+router = APIRouter(prefix="/prices", tags=["prices"])
+
+@router.post("/", response_model=PriceResponse, status_code=201)
+async def create_price_endpoint(
+    price: PriceCreate,
+    db: Session = Depends(get_db)
+):
+    product = get_product_by_id(db=db, product_id=price.product_id)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    store = db.query(Stores).filter(Stores.id == price.store_id).first()
+    if not store:
+        raise HTTPException(status_code=404, detail="Store not found")
+
+    db_price = create_price(
+        db=db,
+        product_id=price.product_id,
+        store_id=price.store_id,
+        price=price.price,
+        url=price.url
+    )
+    return PriceResponse.model_validate(db_price)

--- a/app/routers/product_router.py
+++ b/app/routers/product_router.py
@@ -1,0 +1,110 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from app.schema.product_schemas import (
+    ProductResponse, 
+    ProductWithPricesResponse, 
+    PriceWithStore,
+    StoreBase,
+    ProductCreate
+)
+from app.cruds.product_crud import (
+    get_products, 
+    get_product_by_id,
+    create_product
+)
+from app.models.models import Prices, Stores
+
+from app.database import get_db
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+@router.get("/", response_model=List[ProductResponse])
+async def get_products_endpoint(
+    db: Session = Depends(get_db),
+    name: Optional[str] = Query(None),
+    min_price: Optional[int] = Query(None),
+    max_price: Optional[int] = Query(None),
+    game: Optional[str] = Query(None),
+    product_type: Optional[str] = Query(None),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000) # Asumo que no nos vamos a traer todo, meto un simple skip/limit al endpoint
+):
+    products = get_products(
+        db=db,
+        name=name,
+        min_price=min_price,
+        max_price=max_price,
+        game=game,
+        product_type=product_type,
+        skip=skip,
+        limit=limit
+    )
+
+    return [ProductResponse.model_validate(product) for product in products]
+
+@router.get("/{product_id}", response_model=ProductWithPricesResponse)
+async def get_product_detail(
+    product_id: int,
+    db: Session = Depends(get_db)
+):
+    product = get_product_by_id(db=db, product_id=product_id)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    prices_query = (
+        db.query(Prices, Stores)
+        .join(Stores, Prices.store_id == Stores.id)
+        .filter(Prices.product_id == product_id)
+        .all()
+    )
+
+    prices_with_stores = []
+    for price, store in prices_query:
+        price_with_store = PriceWithStore(
+            id=price.id,
+            price=price.price,
+            url=price.url,
+            scrapped_at=price.scrapped_at,
+            store=StoreBase(
+                id=store.id,
+                name=store.name,
+                website_url=store.website_url
+            )
+        )
+        prices_with_stores.append(price_with_store)
+
+    product_response = ProductWithPricesResponse(
+        id=product.id,
+        name=product.name,
+        img_url=product.img_url,
+        min_price=product.min_price,
+        game=product.game,
+        edition=product.edition,
+        language=product.language,
+        description=product.description,
+        condition=product.condition,
+        product_type=product.product_type,
+        prices=prices_with_stores
+    )
+
+    return product_response
+
+@router.post("/", response_model=ProductResponse, status_code=201)
+async def create_product_endpoint(
+    product: ProductCreate,
+    db: Session = Depends(get_db)
+):
+    db_product = create_product(
+        db=db,
+        name=product.name,
+        game=product.game,
+        product_type=product.product_type,
+        img_url=product.img_url,
+        min_price=product.min_price,
+        edition=product.edition,
+        language=product.language,
+        description=product.description,
+        condition=product.condition
+    )
+    return ProductResponse.model_validate(db_product)

--- a/app/routers/store_router.py
+++ b/app/routers/store_router.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app.schema.product_schemas import (
+    StoreBase,
+    StoreCreate
+)
+from app.cruds.store_crud import (
+    create_store
+)
+
+from app.database import get_db
+
+router = APIRouter(prefix="/stores", tags=["stores"])
+
+@router.post("/", response_model=StoreBase, status_code=201)
+async def create_store_endpoint(
+    store: StoreCreate,
+    db: Session = Depends(get_db)
+):
+    db_store = create_store(db=db, name=store.name, website_url=store.website_url)
+    return StoreBase.model_validate(db_store)

--- a/app/schema/product_schemas.py
+++ b/app/schema/product_schemas.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+from typing import List, Optional
+
+class StoreBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    name: str
+    website_url: str
+
+class StoreCreate(BaseModel):
+    name: str
+    website_url: str
+
+class PriceWithStore(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    price: int
+    url: str
+    scrapped_at: datetime
+    store: StoreBase
+
+class ProductBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    name: str
+    img_url: Optional[str] = None
+    min_price: Optional[int] = None
+    game: str
+    edition: Optional[str] = None
+    language: Optional[str] = None
+    description: Optional[str] = None
+    condition: Optional[str] = None
+    product_type: str
+
+class ProductCreate(BaseModel):
+    name: str
+    img_url: Optional[str] = None
+    min_price: Optional[int] = None
+    game: str
+    edition: Optional[str] = None
+    language: Optional[str] = None
+    description: Optional[str] = None
+    condition: Optional[str] = None
+    product_type: str
+
+class ProductResponse(ProductBase):
+    pass
+
+class ProductWithPricesResponse(ProductBase):
+    prices: List[PriceWithStore] = []
+
+class PriceCreate(BaseModel):
+    product_id: int
+    store_id: int
+    price: int
+    url: str
+
+class PriceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    product_id: int
+    store_id: int
+    price: int
+    url: str
+    scrapped_at: datetime

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,6 @@ services:
       - db
     environment:
       DATABASE_URL: postgresql://user:password@db:5432/mydb
+    command: bash -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 volumes:
   postgres_data:


### PR DESCRIPTION
## Descripción
Esta PR añade 5 endpoints.
* GET `/products`
  * Admite filtros en query params
* GET `/products/:id`
* POST `/products`
* POST `/stores`
* POST `/prices`

## Video

https://github.com/user-attachments/assets/74b733c8-d2a4-42cb-8e03-0583956f7698

## Notas
1. Añadi simples POST endpoints para poder facilmente testear la funcionalidad, debiese ser más robusto a la hora de conectar con los scrapers.
2. El GET `/products` viene con los parametros `skip` y `limit` para no retornar toda la query.
3. Paso el command del Dockerfile al docker-compose para ahi pasar las migraciones alembic, nose si esa sea la opción más simple/bonita, pero funcionó (para que le echen un ojo para ver que onda).